### PR TITLE
Fix gifler dependency, prepend tag with "v"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "concurrently": "^3.1.0",
     "cpx": "^1.5.0",
     "deeplearn": "file:deeplearn",
-    "gifler": "git://github.com/themadcreator/gifler.git#0.3.0",
+    "gifler": "git://github.com/themadcreator/gifler.git#v0.3.0",
     "gsap": "^1.20.2",
     "ncp": "^2.0.0",
     "nib": "^1.1.2",


### PR DESCRIPTION
The gifler tag should be v0.3.0, instead of 0.3.0, see https://github.com/themadcreator/gifler/tree/v0.3.0.
Fixes dependency error.